### PR TITLE
Avoid attribute conflicts between projects

### DIFF
--- a/src/LightObjects.Generated/GeneratedIdentifierSourceGenerator.cs
+++ b/src/LightObjects.Generated/GeneratedIdentifierSourceGenerator.cs
@@ -57,7 +57,7 @@ public sealed class GeneratedIdentifierSourceGenerator : IIncrementalGenerator
                       /// The underlying type to use as the strongly typed identifier.
                       /// </typeparam>
                       [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class)]
-                      public sealed class {GeneratedIdentifierAttributeName}<TIdentifier> : Attribute;
+                      internal sealed class {GeneratedIdentifierAttributeName}<TIdentifier> : Attribute;
                       """;
         context.AddSource(GeneratedIdentifierAttributeHint, SourceText.From(source, Encoding.UTF8));
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.cs
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.cs
@@ -125,7 +125,7 @@ public sealed class GeneratedIdentifierSourceGeneratorTests
                      namespace LightObjects.Generated;
 
                      [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class)]
-                     public sealed class GeneratedIdentifierAttribute<TIdentifier> : Attribute;
+                     internal sealed class GeneratedIdentifierAttribute<TIdentifier> : Attribute;
                      """;
     }
 


### PR DESCRIPTION
## Summary
- mark `GeneratedIdentifierAttribute` as `internal`
- update unit tests to use internal accessibility

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_686af4d214e08328ac608add8bf5aa09