### PR TITLE
Upgrade LightObjects to .NET 8/9/10 and LightResults 10.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,16 +17,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.x
-
-    - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 7.x
-
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v4
       with:
@@ -37,6 +27,11 @@ jobs:
       with:
         dotnet-version: 9.x
 
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.x
+
     - name: Restore dependencies
       run: dotnet restore
 
@@ -44,7 +39,7 @@ jobs:
       run: |
         dotnet build ./src/LightObjects/LightObjects.csproj --configuration Release --no-restore
         dotnet pack ./src/LightObjects/LightObjects.csproj --configuration Release --no-build --output .
-    
+
     - name: Pack LightObjects.Generated
       run: |
         dotnet build ./src/LightObjects.Generated/LightObjects.Generated.csproj --configuration Release --no-restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,6 @@ jobs:
         with:
           languages: 'csharp'
 
-      - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.x
-
-      - name: Setup .NET 7.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.x
-
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
         with:
@@ -45,6 +35,11 @@ jobs:
         with:
           dotnet-version: 9.x
 
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -52,7 +47,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal --framework net8.0
+        run: dotnet test --configuration Release --no-build --verbosity normal
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/src/LightObjects.Generated/LightObjects.Generated.csproj
+++ b/src/LightObjects.Generated/LightObjects.Generated.csproj
@@ -3,7 +3,7 @@
     <!-- Compilation -->
     <PropertyGroup>
         <RootNamespace>LightObjects.Generated</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/src/LightObjects.Generated/LightObjects.Generated.csproj
+++ b/src/LightObjects.Generated/LightObjects.Generated.csproj
@@ -3,7 +3,7 @@
     <!-- Compilation -->
     <PropertyGroup>
         <RootNamespace>LightObjects.Generated</RootNamespace>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -41,9 +41,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>LightObjects.Generated</AssemblyName>
-        <Version>9.0.0-preview.4</Version>
-        <AssemblyVersion>9.0.0.0</AssemblyVersion>
-        <FileVersion>9.0.0.0</FileVersion>
+        <Version>10.0.0-preview.1</Version>
+        <AssemblyVersion>10.0.0.0</AssemblyVersion>
+        <FileVersion>10.0.0.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>

--- a/src/LightObjects/LightObjects.csproj
+++ b/src/LightObjects/LightObjects.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!-- Compilation -->
     <PropertyGroup>
         <RootNamespace>LightObjects</RootNamespace>
-        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -17,19 +17,19 @@
 
     <!-- References -->
     <ItemGroup>
-        <PackageReference Include="LightResults" Version="9.0.0" />
+        <PackageReference Include="LightResults" Version="10.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>LightObjects</AssemblyName>
-        <Version>9.0.0-preview.2</Version>
-        <AssemblyVersion>9.0.0.0</AssemblyVersion>
-        <FileVersion>9.0.0.0</FileVersion>
+        <Version>10.0.0-preview.1</Version>
+        <AssemblyVersion>10.0.0.0</AssemblyVersion>
+        <FileVersion>10.0.0.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
-        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
         <!--<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>-->
     </PropertyGroup>
 

--- a/src/LightObjects/LightObjects.csproj
+++ b/src/LightObjects/LightObjects.csproj
@@ -29,7 +29,7 @@
         <FileVersion>10.0.0.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
-        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+        <IsAotCompatible>true</IsAotCompatible>
         <!--<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>-->
     </PropertyGroup>
 

--- a/tests/LightObjects.Generated.Fixtures/LightObjects.Generated.Fixtures.csproj
+++ b/tests/LightObjects.Generated.Fixtures/LightObjects.Generated.Fixtures.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LightResults" Version="9.0.0" />
+        <PackageReference Include="LightResults" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -22,9 +22,9 @@
                           PrivateAssets="all"
                           ReferenceOutputAssembly="false"
                           OutputItemType="Analyzer"
-                          SetTargetFramework="TargetFramework=netstandard2.0"/>
+                          SetTargetFramework="TargetFramework=net8.0"/>
     </ItemGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\..\src\LightObjects\LightObjects.csproj" />
     </ItemGroup>

--- a/tests/LightObjects.Generated.Tests/LightObjects.Generated.Tests.csproj
+++ b/tests/LightObjects.Generated.Tests/LightObjects.Generated.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary
- retarget library, generator, and test projects to net8.0, net9.0, and net10.0 while bumping package versions to 10.0.0-preview.1
- upgrade LightResults dependencies to 10.0.0 across the solution
- align CI workflows to install .NET 8/9/10 and run tests across all target frameworks

## Testing
- not run (per repository instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ea1e85c483288e6299f145815172)