### PR TITLE
Handle string input in generated TypeConverters

### DIFF
--- a/src/LightObjects.Generated/GeneratedIdentifierSourceGenerator.cs
+++ b/src/LightObjects.Generated/GeneratedIdentifierSourceGenerator.cs
@@ -696,14 +696,19 @@ public sealed class GeneratedIdentifierSourceGenerator : IIncrementalGenerator
                                 {
                                     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
                                     {
-                                        return sourceType == typeof({{declaredValueType}}) || base.CanConvertFrom(context, sourceType);
+                                        return sourceType == typeof(string)
+                                            || sourceType == typeof({{declaredValueType}})
+                                            || base.CanConvertFrom(context, sourceType);
                                     }
-                                
+
                                     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
                                     {
                                         if (value is {{declaredValueType}} identifierValue)
                                             return {{symbolName}}.Create(identifierValue);
-                                
+
+                                        if (value is string stringValue)
+                                            return {{(declaredValueType == "string" ? $"{symbolName}.Create(stringValue)" : $"{symbolName}.Parse(stringValue)")}};
+
                                         return base.ConvertFrom(context, culture, value);
                                     }
                                 }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateGuidIdentifier_WithNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateGuidIdentifier_WithNamespace.verified.txt
@@ -199,13 +199,18 @@ public sealed class TestGuidIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(Guid) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(Guid)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is Guid identifierValue)
             return TestGuidId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestGuidId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateGuidIdentifier_WithoutNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateGuidIdentifier_WithoutNamespace.verified.txt
@@ -197,13 +197,18 @@ public sealed class TestGuidIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(Guid) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(Guid)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is Guid identifierValue)
             return TestGuidId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestGuidId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateIntIdentifier_WithNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateIntIdentifier_WithNamespace.verified.txt
@@ -209,13 +209,18 @@ public sealed class TestIntIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(int) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(int)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is int identifierValue)
             return TestIntId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestIntId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateIntIdentifier_WithoutNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateIntIdentifier_WithoutNamespace.verified.txt
@@ -207,13 +207,18 @@ public sealed class TestIntIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(int) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(int)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is int identifierValue)
             return TestIntId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestIntId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateLongIdentifier_WithNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateLongIdentifier_WithNamespace.verified.txt
@@ -209,13 +209,18 @@ public sealed class TestLongIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(long) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(long)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is long identifierValue)
             return TestLongId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestLongId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateLongIdentifier_WithoutNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateLongIdentifier_WithoutNamespace.verified.txt
@@ -207,13 +207,18 @@ public sealed class TestLongIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(long) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(long)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is long identifierValue)
             return TestLongId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestLongId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateShortIdentifier_WithNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateShortIdentifier_WithNamespace.verified.txt
@@ -209,13 +209,18 @@ public sealed class TestShortIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(short) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(short)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is short identifierValue)
             return TestShortId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestShortId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateShortIdentifier_WithoutNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateShortIdentifier_WithoutNamespace.verified.txt
@@ -207,13 +207,18 @@ public sealed class TestShortIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(short) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(short)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is short identifierValue)
             return TestShortId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestShortId.Parse(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateStringIdentifier_WithNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateStringIdentifier_WithNamespace.verified.txt
@@ -199,13 +199,18 @@ public sealed class TestStringIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(string)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is string identifierValue)
             return TestStringId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestStringId.Create(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }

--- a/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateStringIdentifier_WithoutNamespace.verified.txt
+++ b/tests/LightObjects.Generated.Tests/GeneratedIdentifierSourceGeneratorTests.GenerateStringIdentifier_WithoutNamespace.verified.txt
@@ -197,13 +197,18 @@ public sealed class TestStringIdTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        return sourceType == typeof(string)
+            || sourceType == typeof(string)
+            || base.CanConvertFrom(context, sourceType);
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         if (value is string identifierValue)
             return TestStringId.Create(identifierValue);
+
+        if (value is string stringValue)
+            return TestStringId.Create(stringValue);
 
         return base.ConvertFrom(context, culture, value);
     }


### PR DESCRIPTION
## Summary
- make the generated identifier type converter advertise support for strings and parse textual values into identifiers
- update the generator snapshots to reflect the revised converter output across the numeric, GUID, and string identifier scenarios

## Testing
- `dotnet test tests/LightObjects.Generated.Tests/LightObjects.Generated.Tests.csproj -f net10.0`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1bbd58fc832880c2a5a4dab81d09)